### PR TITLE
Feature/german rmt

### DIFF
--- a/Encounters/RMT/Octog.lua
+++ b/Encounters/RMT/Octog.lua
@@ -64,6 +64,17 @@ mod:RegisterFrenchLocale({
     ["buff.octog.flamethrower"] = "Feu spatial",
   }
 )
+mod:RegisterGermanLocale({
+    -- Unit names.
+    ["unit.octog"] = "Sternenschlinger der Gefräßige",
+    -- NPC says.
+    ["say.octog.orb"] = "Bleibt schön in der Nähe! Gleich gibt’s was zu futtern!",
+    ["say.octog.supernova"] = "Bald wirst du aufhören zu zappeln ... und mein Bauch aufhören zu grummeln!",
+    -- Buffs.
+    ["buff.orb.energies"] = "Chaotische Energien",
+    ["buff.octog.flamethrower"] = "Weltraumfeuer",
+  }
+)
 ----------------------------------------------------------------------------------------------------
 -- Settings.
 ----------------------------------------------------------------------------------------------------

--- a/Encounters/RMT/Starmap.lua
+++ b/Encounters/RMT/Starmap.lua
@@ -93,7 +93,6 @@ mod:RegisterGermanLocale({
     -- Buffs.
     ["buff.alpha.wind"] = "Solarwinde",
     ["buff.alpha.irradiated"] = "Verstrahlte Rüstung",
-    ["buff.debris.mass.accumulating"] = "Accumulating Mass",
     -- Datachron.
     -- Bugged ["chron.world_ender.aldinari"] = "A World Ender is heading to the (rvl_target.name) orbit.", --
     -- Bugged ["chron.world_ender.vulpes_nix"] = "A World Ender is heading to the (rvl_target.name) orbit.",

--- a/Encounters/RMT/Starmap.lua
+++ b/Encounters/RMT/Starmap.lua
@@ -82,6 +82,25 @@ mod:RegisterFrenchLocale({
     ["chron.world_ender.cassus"] = "A World Ender is heading to the de Cassus orbit.",
   }
 )
+mod:RegisterGermanLocale({
+    -- Unit names.
+    ["unit.alpha"] = "Alpha-Cassus",
+
+    ["unit.asteroid"] = "Abnormaler Asteroid",
+    ["unit.debris_field"] = "Trümmerfeld",
+    -- Cast names.
+    ["cast.alpha.catastrophic"] = "Katastrophales Sonnenereignis",
+    -- Buffs.
+    ["buff.alpha.wind"] = "Solarwinde",
+    ["buff.alpha.irradiated"] = "Verstrahlte Rüstung",
+    ["buff.debris.mass.accumulating"] = "Accumulating Mass",
+    -- Datachron.
+    -- Bugged ["chron.world_ender.aldinari"] = "A World Ender is heading to the (rvl_target.name) orbit.", --
+    -- Bugged ["chron.world_ender.vulpes_nix"] = "A World Ender is heading to the (rvl_target.name) orbit.",
+    -- Bugged ["chron.world_ender.cassus"] = "A World Ender is heading to the (rvl_target.name) orbit.",
+    ["chron.critical_mass"] = "([^%s]+%s[^%s]+) hat kritische Masse erreicht!",
+  }
+)
 ----------------------------------------------------------------------------------------------------
 -- Settings.
 ----------------------------------------------------------------------------------------------------


### PR DESCRIPTION
Adds german locales for Octog and Starmap.
Starmap is still bugged since the world ender datachrons don't work on the german client.